### PR TITLE
Added a missing call to vuex::mapState

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -18,7 +18,6 @@ export default {
   components: {
     Controller
   },
-  computed: {
-  }
+  computed: mapState()
 }
 </script>


### PR DESCRIPTION
The project could not be compiled locally
because of a missing call to vuex::mapState
in layouts/default.vue. This commit adds
the missing call to the culprit file.