### PR TITLE
Added missing sidebar

### DIFF
--- a/assets/styles/components/_layout.scss
+++ b/assets/styles/components/_layout.scss
@@ -3,6 +3,7 @@
   --space: 15px;
   --avatar-size: 35px;
   --sidebar-width: 210px;
+  --controller-layer: 10;
 
   @include breakpoint(medium) {
     --avatar-size: 40px;
@@ -142,7 +143,7 @@
   top: 0;
   transition: min-height $ease;
   width: calc(100% - var(--sidebar-width));
-  z-index: 10;
+  z-index: var(--controller-layer);
 
   @include breakpoint(medium down) {
     width: 100vw;

--- a/assets/styles/components/_layout.scss
+++ b/assets/styles/components/_layout.scss
@@ -177,12 +177,6 @@
   }
 }
 
-.sidebar {
-  background-color: $gray-dark;
-  flex-shrink: 0;
-  width: var(--sidebar-width);
-}
-
 .icon--title {
   align-items: center;
   display: flex;

--- a/assets/styles/components/_layout.scss
+++ b/assets/styles/components/_layout.scss
@@ -178,6 +178,7 @@
 }
 
 .sidebar {
+  background-color: $gray-dark;
   flex-shrink: 0;
   width: var(--sidebar-width);
 }

--- a/components/LeftSidebar.vue
+++ b/components/LeftSidebar.vue
@@ -34,7 +34,7 @@ export default {
   align-items: center;
   border-bottom-style: solid;
   border-color: $gray;
-  color: #fff;
+  color: $white;
   display: flex;
   justify-content: flex-start;
   padding: 1rem;
@@ -59,7 +59,7 @@ export default {
   /* For NuxtLinks inside sidebaritems */
   a {
     align-items: center;
-    color: #fff;
+    color: $white;
     display: flex;
     padding: 1rem;
     width: 100%;

--- a/components/LeftSidebar.vue
+++ b/components/LeftSidebar.vue
@@ -94,7 +94,8 @@ export default {
   /* For NuxtLinks inside sidebaritems */
   > a {
     align-items: center;
-    border-bottom-style: dotted;
+    border-bottom-style: solid;
+    border-bottom-width: thin;
     border-color: $gray;
     color: $white;
     display: flex;

--- a/components/LeftSidebar.vue
+++ b/components/LeftSidebar.vue
@@ -65,6 +65,12 @@ export default {
   background-color: $gray-dark;
   flex-shrink: 0;
   width: var(--sidebar-width);
+  z-index: calc(var(--controller-layer) + 2);
+
+  /*  &.sidebarOpen {
+    transform: translateX(var(--sidebar-width));
+    transition: 0.3s;
+  } */
 
   .sidebartitle {
     align-items: center;

--- a/components/LeftSidebar.vue
+++ b/components/LeftSidebar.vue
@@ -32,6 +32,8 @@ export default {
 <style lang="scss">
 .sidebartitle {
   align-items: center;
+  border-bottom-style: solid;
+  border-color: $gray;
   color: #fff;
   display: flex;
   justify-content: flex-start;
@@ -44,6 +46,8 @@ export default {
 
 .sidebaritem {
   align-items: center;
+  border-bottom-style: dotted;
+  border-color: $gray;
   display: flex;
   padding: 1rem;
   width: 100%;

--- a/components/LeftSidebar.vue
+++ b/components/LeftSidebar.vue
@@ -65,12 +65,6 @@ export default {
   background-color: $gray-dark;
   flex-shrink: 0;
   width: var(--sidebar-width);
-  z-index: calc(var(--controller-layer) + 2);
-
-  /*  &.sidebarOpen {
-    transform: translateX(var(--sidebar-width));
-    transition: 0.3s;
-  } */
 
   .sidebartitle {
     align-items: center;

--- a/components/LeftSidebar.vue
+++ b/components/LeftSidebar.vue
@@ -6,7 +6,7 @@
     </div>
     <div v-if="this.$auth.loggedIn" class="sidebaritems">
       <div
-        v-for="menuitem in menu_items"
+        v-for="menuitem in filteredMenuItems"
         :key="menuitem.label"
         class="sidebaritem"
       >
@@ -25,10 +25,39 @@
 </template>
 
 <script>
+import { mapState } from 'vuex'
+
 export default {
   computed: {
-    menu_items() {
-      return this.$store.state.nav.menuItems
+    ...mapState({
+      menuItems: (state) => state.nav.menuItems
+    }),
+    ...mapState({
+      profileAbilities: (state) => state.profile.profileAbilities
+    }),
+    ...mapState({
+      requiredUserViewRights: (state) =>
+        state.nav.menuItems[2].requiredAbilities
+    }),
+    filteredMenuItems() {
+      const filteredItems = []
+      for (const item of this.menuItems) {
+        if (item.label === 'Users') {
+          let allowedToViewUsers = false
+          for (const ability of this.$auth.user.communityAbilities) {
+            if (ability.kind === 2002) {
+              allowedToViewUsers = true
+              break
+            }
+          }
+          if (allowedToViewUsers) {
+            filteredItems.push(item)
+          }
+        } else {
+          filteredItems.push(item)
+        }
+      }
+      return filteredItems
     }
   }
 }
@@ -55,17 +84,21 @@ export default {
 
 .sidebaritem {
   align-items: center;
-  border-bottom-style: dotted;
-  border-color: $gray;
   display: flex;
-  height: 70px;
   width: 100%;
 
+  > div {
+    display: none;
+  }
+
   /* For NuxtLinks inside sidebaritems */
-  a {
+  > a {
     align-items: center;
+    border-bottom-style: dotted;
+    border-color: $gray;
     color: $white;
     display: flex;
+    height: 70px;
     padding: 1rem;
     width: 100%;
 

--- a/components/LeftSidebar.vue
+++ b/components/LeftSidebar.vue
@@ -2,7 +2,7 @@
   <div class="sidebar">
     <div class="sidebartitle">
       <img src="~/assets/icons/credentify.svg" alt="Credentify logo" />
-      Credentify
+      <span>Credentify</span>
     </div>
     <div v-if="this.$auth.loggedIn" class="sidebaritems">
       <div
@@ -42,6 +42,10 @@ export default {
   img {
     padding-right: 10px;
   }
+
+  span {
+    font-weight: bold;
+  }
 }
 
 .sidebaritem {
@@ -49,7 +53,6 @@ export default {
   border-bottom-style: dotted;
   border-color: $gray;
   display: flex;
-  padding: 1rem;
   width: 100%;
 
   /* For NuxtLinks inside sidebaritems */
@@ -57,6 +60,7 @@ export default {
     align-items: center;
     color: #fff;
     display: flex;
+    padding: 1rem;
     width: 100%;
 
     img {
@@ -64,5 +68,10 @@ export default {
       width: 25px;
     }
   }
+}
+
+.sidebaritem:hover {
+  border-left-color: $blue-light;
+  border-left-style: solid;
 }
 </style>

--- a/components/LeftSidebar.vue
+++ b/components/LeftSidebar.vue
@@ -53,6 +53,7 @@ export default {
   border-bottom-style: dotted;
   border-color: $gray;
   display: flex;
+  height: 70px;
   width: 100%;
 
   /* For NuxtLinks inside sidebaritems */

--- a/components/LeftSidebar.vue
+++ b/components/LeftSidebar.vue
@@ -1,0 +1,48 @@
+<template>
+  <div class="sidebar">
+    <div class="icon--title">
+      <img
+        class="mr-1"
+        src="~/assets/icons/credentify.svg"
+        alt="Credentify logo"
+      />
+      Credentify
+    </div>
+    <div v-if="this.$auth.loggedIn" class="links">
+      <ul>
+        <li
+          v-for="menuitem in menu_items"
+          :key="menuitem.label"
+          class="sidebaritem"
+        >
+          <NuxtLink :to="menuitem.url">
+            <img :src="menuitem.icon" />
+            {{ menuitem.label }}
+          </NuxtLink>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  computed: {
+    menu_items() {
+      return this.$store.state.nav.menuItems
+    }
+  }
+}
+</script>
+
+<style lang="scss">
+.sidebaritem {
+  align-items: left;
+  list-style-type: none;
+  width: 100%;
+
+  img {
+    margin-right: 10px;
+  }
+}
+</style>

--- a/components/LeftSidebar.vue
+++ b/components/LeftSidebar.vue
@@ -64,63 +64,73 @@ export default {
 </script>
 
 <style lang="scss">
-.sidebartitle {
-  align-items: center;
-  border-bottom-style: solid;
-  border-color: $gray;
-  color: $white;
-  display: flex;
-  justify-content: flex-start;
-  padding: 1rem;
+.sidebar {
+  background-color: $gray-dark;
+  flex-shrink: 0;
+  width: var(--sidebar-width);
 
-  img {
-    padding-right: 10px;
-  }
-
-  span {
-    font-weight: bold;
-  }
-}
-
-.sidebaritem {
-  align-items: center;
-  display: flex;
-  width: 100%;
-
-  /* For NuxtLinks inside sidebaritems */
-  > a {
+  .sidebartitle {
     align-items: center;
     border-bottom-style: solid;
-    border-bottom-width: thin;
     border-color: $gray;
     color: $white;
     display: flex;
-    height: 70px;
+    justify-content: flex-start;
     padding: 1rem;
-    width: 100%;
 
     img {
-      margin-right: 15px;
-      width: 25px;
+      padding-right: 10px;
+    }
+
+    span {
+      font-weight: bold;
     }
   }
-}
 
-.sidebaritem:hover {
-  border-left-color: $blue-light;
-  border-left-style: solid;
-}
+  .sidebaritem {
+    align-items: center;
+    display: flex;
+    width: 100%;
 
-.zeroxcert-advertisement {
-  align-items: center;
-  bottom: 0;
-  font-weight: bold;
-  left: 0;
-  padding: 1rem;
-  position: absolute;
+    /* For NuxtLinks inside sidebaritems */
+    > a {
+      align-items: center;
+      border-bottom-style: solid;
+      border-bottom-width: thin;
+      border-color: $gray;
+      color: $white;
+      display: flex;
+      height: 70px;
+      padding: 1rem;
+      width: 100%;
 
-  > a {
-    color: $gray-light;
+      img {
+        margin-right: 15px;
+        width: 25px;
+      }
+    }
+  }
+
+  .sidebaritem:hover {
+    border-left-color: $blue-light;
+    border-left-style: solid;
+  }
+
+  .zeroxcert-advertisement {
+    align-items: center;
+    background-color: $gray-dark;
+    bottom: 0;
+    font-weight: bold;
+    left: 0;
+    opacity: 1;
+    padding: 1rem;
+    position: absolute;
+    width: var(--sidebar-width);
+
+    > a {
+      color: $gray-light;
+      width: 100%;
+    }
   }
 }
 </style>

--- a/components/LeftSidebar.vue
+++ b/components/LeftSidebar.vue
@@ -16,6 +16,11 @@
         </NuxtLink>
       </div>
     </div>
+    <div class="zeroxcert-advertisement">
+      <a href="https://github.com/0xcert/framework">
+        Powered by <br />0xcert framework
+      </a>
+    </div>
   </div>
 </template>
 
@@ -74,5 +79,18 @@ export default {
 .sidebaritem:hover {
   border-left-color: $blue-light;
   border-left-style: solid;
+}
+
+.zeroxcert-advertisement {
+  align-items: center;
+  bottom: 0;
+  font-weight: bold;
+  left: 0;
+  padding: 1rem;
+  position: absolute;
+
+  > a {
+    color: $gray-light;
+  }
 }
 </style>

--- a/components/LeftSidebar.vue
+++ b/components/LeftSidebar.vue
@@ -1,26 +1,19 @@
 <template>
   <div class="sidebar">
-    <div class="icon--title">
-      <img
-        class="mr-1"
-        src="~/assets/icons/credentify.svg"
-        alt="Credentify logo"
-      />
+    <div class="sidebartitle">
+      <img src="~/assets/icons/credentify.svg" alt="Credentify logo" />
       Credentify
     </div>
     <div v-if="this.$auth.loggedIn" class="links">
-      <ul>
-        <li
-          v-for="menuitem in menu_items"
-          :key="menuitem.label"
-          class="sidebaritem"
-        >
-          <NuxtLink :to="menuitem.url">
-            <img :src="menuitem.icon" />
-            {{ menuitem.label }}
-          </NuxtLink>
-        </li>
-      </ul>
+      <div
+        v-for="menuitem in menu_items"
+        :key="menuitem.label"
+        class="sidebaritem"
+      >
+        <NuxtLink :to="menuitem.url">
+          <img :src="menuitem.icon" />{{ menuitem.label }}
+        </NuxtLink>
+      </div>
     </div>
   </div>
 </template>
@@ -36,13 +29,33 @@ export default {
 </script>
 
 <style lang="scss">
-.sidebaritem {
-  align-items: left;
-  list-style-type: none;
-  width: 100%;
+.sidebartitle {
+  align-items: center;
+  color: #fff;
+  display: flex;
+  justify-content: flex-start;
+  padding: 1rem;
 
   img {
-    margin-right: 10px;
+    padding-right: 10px;
+  }
+}
+
+.sidebaritem {
+  align-items: center;
+  display: flex;
+  padding-bottom: 1rem;
+  padding-left: 20px;
+  padding-right: 30px;
+  padding-top: 1rem;
+
+  /* For NuxtLinks */
+  a {
+    color: #fff;
+
+    img {
+      margin-right: 10px;
+    }
   }
 }
 </style>

--- a/components/LeftSidebar.vue
+++ b/components/LeftSidebar.vue
@@ -30,14 +30,11 @@ import { mapState } from 'vuex'
 export default {
   computed: {
     ...mapState({
-      menuItems: (state) => state.nav.menuItems
-    }),
-    ...mapState({
-      profileAbilities: (state) => state.profile.profileAbilities
-    }),
-    ...mapState({
+      sidebarOpen: (state) => state.nav.sidebarOpen,
+      menuItems: (state) => state.nav.menuItems,
       requiredUserViewRights: (state) =>
-        state.nav.menuItems[2].requiredAbilities
+        state.nav.menuItems[2].requiredAbilities,
+      profileAbilities: (state) => state.profile.profileAbilities
     }),
     filteredMenuItems() {
       const filteredItems = []

--- a/components/LeftSidebar.vue
+++ b/components/LeftSidebar.vue
@@ -4,14 +4,15 @@
       <img src="~/assets/icons/credentify.svg" alt="Credentify logo" />
       Credentify
     </div>
-    <div v-if="this.$auth.loggedIn" class="links">
+    <div v-if="this.$auth.loggedIn" class="sidebaritems">
       <div
         v-for="menuitem in menu_items"
         :key="menuitem.label"
         class="sidebaritem"
       >
         <NuxtLink :to="menuitem.url">
-          <img :src="menuitem.icon" />{{ menuitem.label }}
+          <img :src="menuitem.icon" />
+          <span>{{ menuitem.label }}</span>
         </NuxtLink>
       </div>
     </div>
@@ -44,17 +45,19 @@ export default {
 .sidebaritem {
   align-items: center;
   display: flex;
-  padding-bottom: 1rem;
-  padding-left: 20px;
-  padding-right: 30px;
-  padding-top: 1rem;
+  padding: 1rem;
+  width: 100%;
 
-  /* For NuxtLinks */
+  /* For NuxtLinks inside sidebaritems */
   a {
+    align-items: center;
     color: #fff;
+    display: flex;
+    width: 100%;
 
     img {
-      margin-right: 10px;
+      margin-right: 15px;
+      width: 25px;
     }
   }
 }

--- a/components/LeftSidebar.vue
+++ b/components/LeftSidebar.vue
@@ -87,10 +87,6 @@ export default {
   display: flex;
   width: 100%;
 
-  > div {
-    display: none;
-  }
-
   /* For NuxtLinks inside sidebaritems */
   > a {
     align-items: center;

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,6 +1,7 @@
 <template>
   <div :class="['layout', { loggedin: this.$auth.loggedIn }]">
     <v-dialog />
+    <LeftSidebar />
     <div class="main-canvas">
       <controller />
       <div class="page">
@@ -13,10 +14,12 @@
 <script>
 import { mapState } from 'vuex'
 import Controller from '~/components/Controller'
+import LeftSidebar from '~/components/LeftSidebar'
 
 export default {
   components: {
-    Controller
+    Controller,
+    LeftSidebar
   },
   computed: mapState()
 }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="['layout', { loggedin: this.$auth.loggedIn }]">
+  <div :class="['layout', { sidebarOpen, loggedin: this.$auth.loggedIn }]">
     <v-dialog />
     <LeftSidebar />
     <div class="main-canvas">
@@ -21,6 +21,8 @@ export default {
     Controller,
     LeftSidebar
   },
-  computed: mapState()
+  computed: mapState({
+    sidebarOpen: (state) => state.nav.sidebarOpen
+  })
 }
 </script>


### PR DESCRIPTION
Added the sidebar seen in the production version of Credentify but missing from GitHub. The sidebar is implemented as its own Vue component in `components/LeftSidebar.vue`.

The only really questionable thing in the implementation is the permissions required to view the Users tab. The sidebar uses the user ability `2002` explained in the API documentation to determine whether a user account should have access to the Users tab, but this might have to be changed in the future.